### PR TITLE
Remove null as default

### DIFF
--- a/moon2/crds/moon.aerokube.com_configs.yaml
+++ b/moon2/crds/moon.aerokube.com_configs.yaml
@@ -322,7 +322,6 @@ spec:
                         type: string
                     required:
                     - name
-                    default: null
                 type: object
               user:
                 default: {}


### PR DESCRIPTION
Kubernetes API server removes this value, which results in a reconciliation loop with GitOps tooling